### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "urls": [
-    ["Joystick.py", "github:kishan3/Micropython_Joystick/Joystick.py"]
+    ["Joystick.py", "github:cnadler86/Micropython_Joystick/Joystick.py"]
   ],
   "version": "1.0.0",
   "deps": []

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "urls": [
+    ["Joystick.py", "github:kishan3/Micropython_Joystick/Joystick.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the module compatible with the MicroPython Package Manager (MIP).

With this change, users can install the module using: \

This PR is part of an effort to add package.json to popular MicroPython libraries.